### PR TITLE
Use built-in GITHUB_API_URL

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,4 +20,3 @@ jobs:
             'This PR exceeds the recommended size of 1000 lines.
             Please make sure you are NOT addressing multiple issues with one PR.
             Note this PR might be rejected due to its size.’
-          github_api_url: 'api.github.com' # It would be ideal to test this out pointing to a GitHub Enterprise server, but there are no testing environments available

--- a/README.md
+++ b/README.md
@@ -46,19 +46,21 @@ jobs:
             'This PR exceeds the recommended size of 1000 lines.
             Please make sure you are NOT addressing multiple issues with one PR.
             Note this PR might be rejected due to its size.’
-          github_api_url: 'api.github.com'
 ```
 
 ## 🎛️ Available parameters
 
 - `*_max_size` (`xs_max_size`, `s_max_size`…): Adjust which amount of changes you consider appropriate for each size based on your project context
 - `fail_if_xl`: Set to `'true'` will report GitHub Workflow failure if the PR size is xl allowing to forbid PR merge
-- `github_api_url`: Override this parameter in order to use with your own GitHub Enterprise Server. Example: `'github.example.com/api/v3'`
 
 ## 🤔 Basic concepts or assumptions
 
 - PR size labeler consider as a change any kind of line addition, deletion, or modification
 - A PR will be labeled as `xl` if it exceeds the amount of changes defined as `l_max_size`
+
+## :octocat: GitHub Enterprise Server support
+
+- This Action relies on [default GitHub environment variables](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables) to obtain the correct GitHub instance. Fallback: `https://api.github.com`
 
 ## ⚖️ License
 

--- a/action.yml
+++ b/action.yml
@@ -31,10 +31,6 @@ inputs:
       'This PR exceeds the recommended size of 1000 lines.
       Please make sure you are NOT addressing multiple issues with one PR.
       Note this PR might be rejected due to its size.’
-  github_api_url:
-    description: 'URI to the API of your Github Server, only necessary for Github Enterprise customers'
-    required: false
-    default: 'api.github.com'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -46,7 +42,6 @@ runs:
     - ${{ inputs.l_max_size }}
     - ${{ inputs.fail_if_xl }}
     - ${{ inputs.message_if_xl }}
-    - ${{ inputs.github_api_url }}
 branding:
   icon: 'tag'
   color: 'green'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,18 +2,12 @@
 set -euo pipefail
 
 PR_SIZE_LABELER_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-PR_SIZE_LABELER_API="api.github.com"
 
 if [ "$PR_SIZE_LABELER_HOME" == "/" ]; then
   PR_SIZE_LABELER_HOME=""
 fi
 
-if [ ! -z "$8" ]; then
-    PR_SIZE_LABELER_API=$8
-fi
-
 export PR_SIZE_LABELER_HOME
-export PR_SIZE_LABELER_API
 
 bash --version
 

--- a/src/github.sh
+++ b/src/github.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
-GITHUB_API_URI="https://$PR_SIZE_LABELER_API"
 GITHUB_API_HEADER="Accept: application/vnd.github.v3+json"
 
 github::calculate_total_modifications() {
-  local -r body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URI/repos/$GITHUB_REPOSITORY/pulls/$1")
+  local -r body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls/$1")
 
   local -r additions=$(echo "$body" | jq '.additions')
   local -r deletions=$(echo "$body" | jq '.deletions')
@@ -16,7 +15,7 @@ github::add_label_to_pr() {
   local -r pr_number=$1
   local -r label_to_add=$2
 
-  local -r body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URI/repos/$GITHUB_REPOSITORY/pulls/$1")
+  local -r body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls/$1")
   local labels=$(echo "$body" | jq .labels | jq -r ".[] | .name" | grep -v "size/")
   labels=$(printf "%s\n%s" "$labels" "$label_to_add")
   local -r comma_separated_labels=$(github::format_labels "$labels")
@@ -29,7 +28,7 @@ github::add_label_to_pr() {
     -X PATCH \
     -H "Content-Type: application/json" \
     -d "{\"labels\":[$comma_separated_labels]}" \
-    "$GITHUB_API_URI/repos/$GITHUB_REPOSITORY/issues/$pr_number"
+    "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/issues/$pr_number"
 }
 
 github::format_labels() {
@@ -57,5 +56,5 @@ github::comment() {
     -X POST \
     -H "Content-Type: application/json" \
     -d "{\"body\":\"$comment\"}" \
-    "$GITHUB_API_URI/repos/$GITHUB_REPOSITORY/issues/$pr_number/comments"
+    "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/issues/$pr_number/comments"
 }

--- a/src/main.sh
+++ b/src/main.sh
@@ -9,7 +9,12 @@ source "$PR_SIZE_LABELER_HOME/src/misc.sh"
 main() {
   ensure::env_variable_exist "GITHUB_REPOSITORY"
   ensure::env_variable_exist "GITHUB_EVENT_PATH"
-  ensure::total_args 8 "$@"
+  ensure::total_args 7 "$@"
+
+  if [ -z "$GITHUB_API_URL" ]; then
+    log::message "GITHUB_API_URL not set, using default: https://api.github.com"
+    export GITHUB_API_URL="https://api.github.com"
+  fi
 
   export GITHUB_TOKEN="$1"
 


### PR DESCRIPTION
Fix: #27 

My bog-standard configuration used in a GHES instance to verify it: 
```yaml
    - uses: erodewald/pr-size-labeler@master
      with:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        xs_max_size: '10'
        s_max_size: '100'
        m_max_size: '500'
        l_max_size: '1000'
        fail_if_xl: false
```
