### PR TITLE
feature: Add support for ignoring files (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ jobs:
             Please make sure you are NOT addressing multiple issues with one PR.
             Note this PR might be rejected due to its size.’
           github_api_url: 'api.github.com'
+          files_to_ignore: ''
 ```
 
 ## 🎛️ Available parameters
@@ -59,7 +60,9 @@ jobs:
 - `*_label` (`xs_label`, `s_label`…): Adjust size label names
 - `*_max_size` (`xs_max_size`, `s_max_size`…): Adjust which amount of changes you consider appropriate for each size based on your project context
 - `fail_if_xl`: Set to `'true'` will report GitHub Workflow failure if the PR size is xl allowing to forbid PR merge
+- `message_if_xl`: Let the user(s) know that the PR exceeds the recommended size and what the consequences are
 - `github_api_url`: Override this parameter in order to use with your own GitHub Enterprise Server. Example: `'github.example.com/api/v3'`
+- `files_to_ignore`: List of files to ignore when calculating the PR size. Example: `'package-lock.json Pipfile.lock'`
 
 ## 🤔 Basic concepts or assumptions
 

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: 'URI to the API of your Github Server, only necessary for Github Enterprise customers'
     required: false
     default: 'api.github.com'
+  files_to_ignore:
+    description: 'Whitespace separated list of files to ignore when calculating the PR size (sum of changes)'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -72,6 +76,7 @@ runs:
     - ${{ inputs.fail_if_xl }}
     - ${{ inputs.message_if_xl }}
     - ${{ inputs.github_api_url }}
+    - ${{ inputs.files_to_ignore }}
 branding:
   icon: 'tag'
   color: 'green'

--- a/src/github.sh
+++ b/src/github.sh
@@ -4,12 +4,37 @@ GITHUB_API_URI="https://$PR_SIZE_LABELER_API"
 GITHUB_API_HEADER="Accept: application/vnd.github.v3+json"
 
 github::calculate_total_modifications() {
-  local -r body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URI/repos/$GITHUB_REPOSITORY/pulls/$1")
+  local -r pr_number="${1}"
+  local -r files_to_ignore="${2}"
+  if [ -z "$files_to_ignore" ]; then
+    local -r body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URI/repos/$GITHUB_REPOSITORY/pulls/$pr_number")
 
-  local -r additions=$(echo "$body" | jq '.additions')
-  local -r deletions=$(echo "$body" | jq '.deletions')
+    local -r additions=$(echo "$body" | jq '.additions')
+    local -r deletions=$(echo "$body" | jq '.deletions')
 
-  echo $((additions + deletions))
+    echo $((additions + deletions))
+  else
+    local -r body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URI/repos/$GITHUB_REPOSITORY/pulls/$pr_number/files?per_page=100")
+
+    local changes=0
+
+    for file in $(echo "$body" | jq -r '.[] | @base64'); do
+      _jq() {
+        echo "$file" | base64 -d | jq -r "$1"
+      }
+      local ignore_file=0 # False
+      for file_to_ignore in $files_to_ignore; do
+        if [ "$file_to_ignore" = "$(basename $(_jq '.filename'))" ]; then
+          ignore_file=1 # True
+        fi
+      done
+      if [ $ignore_file -eq 0 ]; then
+        ((changes += $(_jq '.changes')))
+      fi
+    done
+
+    echo $((changes))
+  fi
 }
 
 github::add_label_to_pr() {
@@ -21,7 +46,7 @@ github::add_label_to_pr() {
   local -r l_label="${6}"
   local -r xl_label="${7}"
 
-  local -r body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URI/repos/$GITHUB_REPOSITORY/pulls/$1")
+  local -r body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URI/repos/$GITHUB_REPOSITORY/pulls/$pr_number")
   local labels=$(echo "$body" | jq .labels | jq -r ".[] | .name" | grep -e "$xs_label" -e "$s_label" -e "$m_label" -e "$l_label" -e "$xl_label" -v)
   labels=$(printf "%s\n%s" "$labels" "$label_to_add")
   local -r comma_separated_labels=$(github::format_labels "$labels")

--- a/src/labeler.sh
+++ b/src/labeler.sh
@@ -8,11 +8,13 @@ labeler::label() {
   local -r xl_label="${9}"
   local -r fail_if_xl="${10}"
   local -r message_if_xl="${11}"
+  local -r files_to_ignore="${12}"
 
   local -r pr_number=$(github_actions::get_pr_number)
-  local -r total_modifications=$(github::calculate_total_modifications "$pr_number")
+  local -r total_modifications=$(github::calculate_total_modifications "$pr_number" "$files_to_ignore")
 
-  log::message "Total modifications: $total_modifications"
+  log::message "Total modifications (additions + deletions): $total_modifications"
+  log::message "Ignoring files (if present): $files_to_ignore"
 
   local -r label_to_add=$(labeler::label_for "$total_modifications" "$@")
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -9,11 +9,11 @@ source "$PR_SIZE_LABELER_HOME/src/misc.sh"
 main() {
   ensure::env_variable_exist "GITHUB_REPOSITORY"
   ensure::env_variable_exist "GITHUB_EVENT_PATH"
-  ensure::total_args 13 "$@"
+  ensure::total_args 14 "$@"
 
   export GITHUB_TOKEN="${1}"
 
-  labeler::label "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "${8}" "${9}" "${10}" "${11}" "${12}"
+  labeler::label "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "${8}" "${9}" "${10}" "${11}" "${12}" "${14}"
 
   exit $?
 }


### PR DESCRIPTION
The code basically does what has been described / discussed in issue #9:
- Allow a whitespace(!)-separated list of files to be ignored (`files_to_ignore`)
- If `files_to_ignore` is empty, the old code will be used (see below for the rationale behind this!)
- If `files_to_ignore` is given, it will loop through the list of files and count the `changes`

Plus: Minor modifications:
- Add missing `message_if_xl` parameter description to README.md
- Fix issue #29 

Note however that my code does have its **LIMITATIONS** and should be tested by someone else too:
- Filenames with whitespaces are not supported (never saw that in auto-generated filenames anyway...)
- `files_to_ignore` is global, i.e., filenames will be ignored in every part of the repository
- **Only the first 100 files are taken into account** ❗ (note that the Pulls API endpoint [GET /repos/{owner}/{repo}/pulls/{pull_number}/files](https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files) is paginated and limited to 3000 files max (100 files max per page))

I can live with that limitation due to the fact that we don't open PRs with hundreds of changed files, but this is the reason why my code will fall back to the old code if `files_to_ignore` is empty: to ensure that someone not using the new parameter does not have this limitation at all and falls back to the API endpoint without `/files` at the end.