### PR TITLE
fix: Comment on PR only if the XL label is new

### DIFF
--- a/src/github.sh
+++ b/src/github.sh
@@ -52,6 +52,19 @@ github::calculate_total_modifications() {
   echo $((additions + deletions))
 }
 
+github::has_label() {
+  local -r pr_number="${1}"
+  local -r label_to_check="${2}"
+
+  local -r body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/issues/$pr_number/labels")
+  for label in $(echo "$body" | jq -r '.[] | @base64'); do
+    if [ "$(echo ${label} | base64 -d | jq -r '.name')" = "$label_to_check" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 github::add_label_to_pr() {
   local -r pr_number="${1}"
   local -r label_to_add="${2}"

--- a/src/labeler.sh
+++ b/src/labeler.sh
@@ -25,7 +25,7 @@ labeler::label() {
   github::add_label_to_pr "$pr_number" "$label_to_add" "$xs_label" "$s_label" "$m_label" "$l_label" "$xl_label"
 
   if [ "$label_to_add" == "$xl_label" ]; then
-    if [ -n "$message_if_xl" ]; then
+    if [ -n "$message_if_xl" ] && ! github::has_label "$pr_number" "$label_to_add"; then
       github::comment "$message_if_xl"
     fi
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
This PR addresses issue #19 by publishing the `message_if_xl` only when the `xl_label` is being added to the PR (either the first time, or when the size changes). 
This behavior should cover most use cases while reducing spamming:
- PR becomes `XL` --> Publish message (notify the author)
- New changes pushed to an already `XL` PR --> No message (the author has already been notified once)
- `XL` PR becomes `M` and then again `XL` --> Publish message (notify the author again)

The principle behind the solution is that the developer/author should be notified only when the PR becomes `XL`, and not every time a change is pushed to the same PR. Although discouraged, `XL` PRs are sometimes inevitable, and the developer is well aware of the number of changes he's working with...

## Notes to Reviewer
There is potential to refactor the `jq::base64` function into a more generic one that does not read the input from `$file` but from a positional argument instead. This would allow it to be reused as part of the proposed changes (instead of `echo ${label} | base64 --decode | jq -r '.name'`).

## How to test
1. Create an `L` PR --> the `Size: L` label should be added
2. Push enough changes to make it `XL` --> label should change to `Size: XL` and a comment should be published
3. Push more changes (or re-run the workflow) --> Nothing happens (label stays the same, no comment)
4. Manually change the label to `Size: L` (remove `Size: XL`), and rerun the workflow --> label should change to `Size: XL` and a second comment should be published

## Link to issues addressed
- [ISSUE-19](https://github.com/CodelyTV/pr-size-labeler/issues/19)
