### PR TITLE
make github_token to optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ jobs:
     steps:
       - uses: codelytv/pr-size-labeler@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size/xs'
           xs_max_size: '10'
           s_label: 'size/s'
@@ -71,7 +70,7 @@ jobs:
 
 | Name                    | Required | Default Value        | Description                                                                                                               |
 |-------------------------|----------|----------------------|---------------------------------------------------------------------------------------------------------------------------|
-| `GITHUB_TOKEN`          | Yes      | Automatically supplied| GitHub token needed to interact with the repository.                                                                     |
+| `GITHUB_TOKEN`          | No       | Automatically supplied| GitHub token needed to interact with the repository.                                                                     |
 | `xs_label`              | No       | 'size/xs'            | Label for very small-sized PRs.                                                                                           |
 | `xs_max_size`           | No       | '10'                 | Maximum number of changes allowed for XS-sized PRs.                                                                       |
 | `s_label`               | No       | 'size/s'             | Label for small-sized PRs.                                                                                                |

--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,9 @@ name: 'Pull Request size labeler'
 description: 'Label a PR based on the amount of changes'
 inputs:
   GITHUB_TOKEN:
-    description: 'GitHub token'
-    required: true
+    description: 'GitHub token needed to interact with the repository'
+    required: false
+    default: ${{ github.token }}
   xs_label:
     description: 'Label for xs PR'
     required: false


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [x] Documentation Update

## Description
- Make input `GITHUB_TOKEN` optional. If it not given, use `${{ github.token }}` default (as same as `secrets.GITHUB_TOKEN`)

## Notes to Reviewer
- N/A

## How to test
- See: https://github.com/134130/134130/actions/runs/11320857938/job/31479043014?pr=5

## Link to issues addressed
- N/A
