### PR TITLE
fix: use the add label API rather than patching the entire issue

### DIFF
--- a/src/github.sh
+++ b/src/github.sh
@@ -84,10 +84,10 @@ github::add_label_to_pr() {
   curl -sSL \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "$GITHUB_API_HEADER" \
-    -X PATCH \
+    -X POST \
     -H "Content-Type: application/json" \
     -d "{\"labels\":[$comma_separated_labels]}" \
-    "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/issues/$pr_number" >/dev/null
+    "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/issues/$pr_number/labels" >/dev/null
 }
 
 github::format_labels() {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When adding a Label to the PR, we should use the [Add Label](https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#add-labels-to-an-issue) API rather than the API to [update the entire issue](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#update-an-issue).

The current implementation can lead to unexpected behaviour if another labelling job is running in parallel, e.g., it can remove the label added by another job if timings match.

## Notes to Reviewer

## How to test

## Link to issues addressed
