### PR TITLE
fix: use jfrog artifactory alpine image in pr labeler workflow ESUSDLC-1014

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM paymentology.jfrog.io/pt-docker-virtual-thirdparty/library/alpine/3.15/
 
 RUN apk add --no-cache bash curl jq wget
 RUN mkdir -p "$HOME/bin" && \


### PR DESCRIPTION
**why**
update to pull alpine image from jfrog artifactory to mitigate dockerhub rate limit errors during workflow execution

**how**
- modified the `Dockerfile` to use `paymentology.jfrog.io/pt-docker-virtual-thirdparty/library/alpine/3.15/` instead of `alpine:3.15` from dockerhub

**ref:** ESUSDLC-1014