### PR TITLE
fix(labeler): generate comment after XL label is added

### DIFF
--- a/src/github.sh
+++ b/src/github.sh
@@ -59,9 +59,11 @@ github::has_label() {
   local -r body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/issues/$pr_number/labels")
   for label in $(echo "$body" | jq -r '.[] | @base64'); do
     if [ "$(echo ${label} | base64 -d | jq -r '.name')" = "$label_to_check" ]; then
+      echo "1"
       return 0
     fi
   done
+  echo "0"
   return 1
 }
 

--- a/src/labeler.sh
+++ b/src/labeler.sh
@@ -26,7 +26,7 @@ labeler::label() {
   github::add_label_to_pr "$pr_number" "$label_to_add" "$xs_label" "$s_label" "$m_label" "$l_label" "$xl_label"
 
   if [ "$label_to_add" == "$xl_label" ]; then
-    if [ -n "$message_if_xl" ] && [ -z "$had_label" ]; then
+    if [ -n "$message_if_xl" ] && [ "$had_label" -eq 0 ]; then
       github::comment "$message_if_xl"
     fi
 

--- a/src/labeler.sh
+++ b/src/labeler.sh
@@ -19,13 +19,14 @@ labeler::label() {
   log::message "Ignoring files (if present): $files_to_ignore"
 
   local -r label_to_add=$(labeler::label_for "$total_modifications" "$@")
+  local -r had_label=$(github::has_label "$pr_number" "$label_to_add")
 
   log::message "Labeling pull request with $label_to_add"
 
   github::add_label_to_pr "$pr_number" "$label_to_add" "$xs_label" "$s_label" "$m_label" "$l_label" "$xl_label"
 
   if [ "$label_to_add" == "$xl_label" ]; then
-    if [ -n "$message_if_xl" ] && ! github::has_label "$pr_number" "$label_to_add"; then
+    if [ -n "$message_if_xl" ] && [ -z "$had_label" ]; then
       github::comment "$message_if_xl"
     fi
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When a PR has XL size, the message is not published in the thread after adding the label.

## How to test

<details><summary>Before</summary>
<p>

<img width="1846" height="276" alt="pr-comment-not-generated-on-xl" src="https://github.com/user-attachments/assets/391ea449-d165-4866-8dbf-3c8d49e84c86" />

</p>
</details>

<details><summary>After</summary>
<p>

<img width="1972" height="878" alt="all-workflow" src="https://github.com/user-attachments/assets/9acfb3fd-9391-4f2b-8ee8-782da5fd2abc" />

</p>
</details> 

## Link to issues addressed
- #98
- Fixes #83