### PR TITLE
fix: paginate PR files when counting changes

### DIFF
--- a/src/github.sh
+++ b/src/github.sh
@@ -20,10 +20,7 @@ github::calculate_total_modifications() {
       ((deletions += $(echo "$body" | jq '.deletions')))
     fi
   else
-    # NOTE: this code is not resilient to changes w/ > 100 files as we're not paginating
-    local -r body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls/$pr_number/files?per_page=100")
-
-    for file in $(echo "$body" | jq -r '.[] | @base64'); do
+    for file in $(github::get_pr_files "$pr_number"); do
       filename=$(jq::base64 '.filename')
       status=$(jq::base64 '.status')
       ignore=false
@@ -50,6 +47,32 @@ github::calculate_total_modifications() {
   fi
 
   echo $((additions + deletions))
+}
+
+# Prints each file of the PR as a base64 encoded JSON object, one per line
+github::get_pr_files() {
+  local -r pr_number="${1}"
+  local -r per_page=100
+  local page=1
+  local body
+
+  # 100 is the maximum page size of the API, so a shorter page is the last one
+  while true; do
+    body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls/$pr_number/files?per_page=$per_page&page=$page")
+
+    # A non-array body means the request failed, so stop instead of looping forever
+    if [ "$(echo "$body" | jq -r type 2>/dev/null)" != "array" ]; then
+      break
+    fi
+
+    echo "$body" | jq -r '.[] | @base64'
+
+    if [ "$(echo "$body" | jq length)" -lt "$per_page" ]; then
+      break
+    fi
+
+    page=$((page + 1))
+  done
 }
 
 github::has_label() {

--- a/tests/github_test.sh
+++ b/tests/github_test.sh
@@ -59,3 +59,26 @@ function test_should_ignore_files_with_glob_ignore_file_deletions() {
 
   assert_equals 394 "$(github::calculate_total_modifications "$pr_number" "${files_to_ignore[*]}" "$ignore_line_deletions" "$ignore_file_deletions")"
 }
+
+function test_should_count_changes_across_pages() {
+  ignore_file_deletions='true'
+
+  # Plain function instead of `mock`, as the response has to differ per page:
+  # a full page of 100 files with 2 changes each, then the fixture as last page
+  function curl() {
+    case "$*" in
+      *"page=1") jq -n '[range(100) | {filename: "file-\(.)", status: "modified", additions: 1, deletions: 1}]' ;;
+      *"page=2") cat ./tests/fixtures/pull_request_files_api ;;
+    esac
+  }
+
+  assert_equals $((200 + 2779)) "$(github::calculate_total_modifications "$pr_number" "${files_to_ignore[*]}" "$ignore_line_deletions" "$ignore_file_deletions")"
+}
+
+function test_should_count_nothing_on_error_response() {
+  ignore_file_deletions='true'
+
+  mock curl echo '{"message": "Not Found"}'
+
+  assert_equals 0 "$(github::calculate_total_modifications "$pr_number" "${files_to_ignore[*]}" "$ignore_line_deletions" "$ignore_file_deletions")"
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When `files_to_ignore` or `ignore_file_deletions` is set, the size is calculated from the [list pull request files](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files) API, which returns at most 100 files per page. Only the first page was fetched, so PRs with more than 100 files were under-counted and could receive a smaller label than they should (the code already had a `NOTE` about this).

This change extracts the request into `github::get_pr_files`, which fetches pages until one is shorter than 100 files. It also stops if the response is not a file list (e.g. an API error), so a failed request results in a count of 0 as before instead of looping.

## Notes to Reviewer
The default path (no `files_to_ignore`, `ignore_file_deletions` unset) is unchanged, as it reads `additions` and `deletions` from the pull request itself.

## How to test
Unit tests cover the new behavior:
- `test_should_count_changes_across_pages` mocks a full first page of 100 files followed by the existing fixture as the second page.
- `test_should_count_nothing_on_error_response` mocks an API error object.

Run them with `./install-dependencies.sh && ./lib/bashunit`.

## Link to issues addressed
- N/A
